### PR TITLE
fix(api-gateway): ratelimit behind reverse proxy

### DIFF
--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -37,6 +37,7 @@ async function main() {
   logger.info(`Config: ${toJson(cfg)}`);
 
   const app = express();
+  app.set("trust proxy", true);
   app.use(cors());
   app.use(express.json());
   const server = http.createServer(app);


### PR DESCRIPTION
https://express-rate-limit.mintlify.app/reference/error-codes#err-erl-unexpected-x-forwarded-for

```log
ValidationError: The 'X-Forwarded-For' header is set but the Express 'trust proxy' setting is false (default). This could indicate a misconfiguration which would prevent express-rate-limit from accurately identifying users. See https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR/ for more information.
    at _Validations.<anonymous> (/app/node_modules/express-rate-limit/dist/index.cjs:180:15)
    at _Validations.wrap (/app/node_modules/express-rate-limit/dist/index.cjs:313:18)
    at _Validations.xForwardedForHeader (/app/node_modules/express-rate-limit/dist/index.cjs:178:10)
    at Object.keyGenerator (/app/node_modules/express-rate-limit/dist/index.cjs:542:19)
    at /app/node_modules/express-rate-limit/dist/index.cjs:595:32
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async /app/node_modules/express-rate-limit/dist/index.cjs:576:5 {
  code: 'ERR_ERL_UNEXPECTED_X_FORWARDED_FOR',
  help: 'https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR/'
}
```