### PR TITLE
fix(rabbitmq): dirty queue resist when no consumer

### DIFF
--- a/api-gateway/src/consumers/consume-maybe-stale-job-v1.ts
+++ b/api-gateway/src/consumers/consume-maybe-stale-job-v1.ts
@@ -4,7 +4,7 @@ import { mongoConnectionPool, rabbitmqConnectionPool } from "../connections";
 import logger from "../loggers/logger";
 
 export const setup = () => {
-  rabbitmqConnectionPool.getChannel().assertQueue("", { autoDelete: true }, (error2, q) => {
+  rabbitmqConnectionPool.getChannel().assertQueue("", { exclusive: true, autoDelete: true }, (error2, q) => {
     if (error2) {
       logger.error(error2);
       return;

--- a/api-gateway/src/consumers/consume-maybe-stale-job.ts
+++ b/api-gateway/src/consumers/consume-maybe-stale-job.ts
@@ -4,7 +4,7 @@ import { rabbitmqConnectionPool } from "../connections";
 import logger from "../loggers/logger";
 
 export const setup = () => {
-  rabbitmqConnectionPool.getChannel().assertQueue("", { autoDelete: true }, (error2, q) => {
+  rabbitmqConnectionPool.getChannel().assertQueue("", { exclusive: true, autoDelete: true }, (error2, q) => {
     if (error2) {
       logger.error(error2);
       return;

--- a/api-gateway/src/consumers/consume-worker-doing.ts
+++ b/api-gateway/src/consumers/consume-worker-doing.ts
@@ -5,7 +5,7 @@ import { toJson } from "../utils";
 
 export const setup = () => {
   if (cfg.LOG_WORKER_DOING) {
-    rabbitmqConnectionPool.getChannel().assertQueue("", { autoDelete: true }, (error2, q) => {
+    rabbitmqConnectionPool.getChannel().assertQueue("", { exclusive: true, autoDelete: true }, (error2, q) => {
       if (error2) {
         logger.error(error2);
         return;

--- a/api-gateway/src/consumers/consume-worker-ping.ts
+++ b/api-gateway/src/consumers/consume-worker-ping.ts
@@ -5,7 +5,7 @@ import { toJson } from "../utils";
 
 export const setup = () => {
   if (cfg.LOG_WORKER_PING) {
-    rabbitmqConnectionPool.getChannel().assertQueue("", { autoDelete: true }, (error2, q) => {
+    rabbitmqConnectionPool.getChannel().assertQueue("", { exclusive: true, autoDelete: true }, (error2, q) => {
       if (error2) {
         logger.error(error2);
         return;


### PR DESCRIPTION
Một vài temporary queue trong rabbitmq không tự động delete khi consumer của nó hẹo: nguyên nhân do thiếu config exclusive. Tìm được trên stackoverflow giải thích về vấn đề này: https://stackoverflow.com/questions/21248563/rabbitmq-difference-between-exclusive-and-auto-delete

>exclusive
>Exclusive queues may only be accessed by the current connection, and are deleted when that connection closes. Passive declaration of an exclusive queue by other connections are not allowed.

>auto-delete
>If set, the queue is deleted when all consumers have finished using it. The last consumer can be cancelled either explicitly or because its channel is closed. If there was no consumer ever on the queue, it won't be deleted. Applications can explicitly delete auto-delete queues using the Delete method as normal.